### PR TITLE
Add documentation for distribution rules and predecessor method

### DIFF
--- a/src/content/documents/00-replicator/03-authorization.md
+++ b/src/content/documents/00-replicator/03-authorization.md
@@ -15,7 +15,7 @@ export const projectAuthorization = (a: AuthorizationRules) => a
   .type(Project, p => p.creator)
   .type(ProjectName, n => n.project.creator)
   .type(ProjectName, n => n.project.successors(Invitation, invitation => invitation.project)
-    .selectMany(invitation => invitation.successors(User, user => user))
+    .selectMany(invitation => invitation.guest.predecessor())
   )
   ;
 ```

--- a/src/content/documents/00-replicator/04-distribution.md
+++ b/src/content/documents/00-replicator/04-distribution.md
@@ -14,7 +14,7 @@ For example:
 ```typescript
 const invitedUsers = (project: LabelOf<Project>) =>
   project.successors(Invitation, invitation => invitation.project)
-    .selectMany(invitation => invitation.successors(User, user => user));
+    .selectMany(invitation => invitation.guest.predecessor());
 
 export const projectDistribution = (model: Model) => (d: DistributionRules) => d
   // Share the project name with invited users.
@@ -35,7 +35,7 @@ export const projectDistribution = (model: Model) => (d: DistributionRules) => d
     self.successors(Invitation, invitation => invitation.user)
   ))
   .with(model.given(User).match(self =>
-    self.successors(User, user => user)
+    self.predecessor()
   ));
 ```
 

--- a/src/content/documents/11-reference/05-given-match.md
+++ b/src/content/documents/11-reference/05-given-match.md
@@ -45,23 +45,37 @@ const tasksInProjectAssignedToUser = model.given(Project, User).match((project, 
 );
 ```
 
-Even though the method is called `successors`, it can be also used to return predecessors or siblings.
-To return predecessors, start from the predecessor and use the identity function.
-
-```typescript
-const companyOfProject = model.given(Project).match(project =>
-  project.company.successors(Company, company => company)
-    // ...
-);
-```
-
-Or to return siblings, start from their common predecessor.
+Even though the method is called `successors`, it can be also used to return siblings.
+Start from their common predecessor.
 
 ```typescript
 const otherProjectsInCompany = model.given(Project).match(project =>
   project.company.successors(Project, other => other.company)
     // ...
 );
+```
+
+## Predecessor
+
+If instead of successors or siblings you want to produce a stream of predecessors, use the `predecessor` method.
+Apply the method to the predecessor.
+
+```typescript
+const companyOfProject = model.given(Project).match(project =>
+  project.company.predecessor()
+    // ...
+);
+```
+
+You can even use the `predecessor` method to get the fact itself.
+This is necessary, for example, in a distribution rule where you want to match the user themselves.
+
+```typescript
+const distribution = (r: DistributionRules) => r
+  .share(model.given(User).match(user =>
+    user.successors(UserName, name => name.user)
+      .notExists(name => name.successors(UserName, next => next.prior))
+  )).with(user => user.predecessor())
 ```
 
 ## Exists and Not Exists
@@ -160,7 +174,7 @@ To return the hash of a fact, use the `j.hash` function.
 
 ```typescript
 const projectHashes = model.given(Project).match(project =>
-  project.successors(Project, project => project)
+  project.predecessor()
     .select(project => j.hash(project))
 );
 ```

--- a/src/content/documents/11-reference/10-authorizationrules.md
+++ b/src/content/documents/11-reference/10-authorizationrules.md
@@ -72,7 +72,7 @@ This authorization rule allows guest bloggers to post to the site.
 ```typescript
 const guestBloggers = model.Given(Post).match(post =>
   post.site.successors(GuestInvitation, invitation => invitation.site)
-    .selectMany(invitation => invitation.successors(User, user => user))
+    .selectMany(invitation => invitation.guest.predecessor())
 );
 
 const authorization = (a: AuthorizationRules) => a

--- a/src/content/documents/11-reference/11-distributionrules.md
+++ b/src/content/documents/11-reference/11-distributionrules.md
@@ -1,0 +1,78 @@
+---
+title: "Distribution Rules"
+---
+
+Distribution rules are written in functions taking a `DistributionRules` object as a parameter.
+
+```typescript
+export const distribution = (r: DistributionRules) => r
+    // rules...
+```
+
+### DistributionRules.share
+
+Each rule describes what can be done with a specification.
+Specifically, you share a specification with certain users.
+Call the `share` method and pass in a specification.
+
+```typescript
+const distribution = (r: DistributionRules) => r
+  .share(model.given(Blog).match(blog =>
+    blog.successors(Post, post => post.blog)
+      .exists(post => post.successors(Publish, publish => publish.post))
+  )). // Then describe who to share it with
+```
+
+### ShareTarget.withEveryone
+
+You can share a specification with everyone or with specific users.
+If you share with everyone, then anybody can run that specification and see the results.
+
+```typescript
+export const distribution = (r: DistributionRules) => r
+  // Everyone can see published posts
+  .share(model.given(Blog).match(blog =>
+    blog.successors(Post, post => post.blog)
+      .exists(post => post.successors(Publish, publish => publish.post))
+  )).withEveryone()
+```
+
+### ShareTarget.with
+
+To control who can run the specification, share with specific users.
+Call the `with` method and pass in a specification that selects the users.
+The specification starts at the same givens as the specification you are sharing.
+
+```typescript
+export const distribution = (r: DistributionRules) => r
+  // The creator can see all posts and comments
+  .share(model.given(Blog).select(blog => ({
+    posts: blog.successors(Post, post => post.blog),
+    comments: blog.successors(Comment, comment => comment.post.blog)
+  }))).with(model.given(Blog).match(blog =>
+    blog.creator.predecessor()
+  ))
+  // A comment author can see their own comments on published posts
+  .share(model.given(Blog, User).match((blog, author) =>
+    blog.successors(Post, post => post.blog)
+      .exists(post => post.successors(Publish, publish => publish.post))
+      .selectMany(post => post.successors(Comment, comment => comment.post)
+        .join(comment => comment.author, author)
+      )
+  )).with(model.given(Blog, User).select((blog, author) =>
+    author
+  ));
+```
+
+### DistributionRules.with
+
+You can compose distribution functions using the `with` method.
+
+```typescript
+const otherDistributionFunction = (r: DistributionRules) => r
+  // ...
+  ;
+const distribution = (r: DistributionRules) => r
+  .with(otherDistributionFunction)
+  ;
+```


### PR DESCRIPTION
Enhance documentation by adding a section on distribution rules and clarifying the usage of the predecessor method in the context of existing functions.